### PR TITLE
Auto Complete Tags in Vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ List of interesting theming-related configurations.
 
 ## Other customizations
 
+- [Auto Complete Yaml Tags from Vim](https://github.com/RyanGreenup/Note-Taking-Tools/blob/master/auto-complete-tags-vim/Auto-Complete-Tags.md)
+
 List of other interesting customizations, mainly involving third-party tools.
 
-- _No customizations yet_


### PR DESCRIPTION
I included a link to my repo with a way to auto-complete links in vim that others might find helpful.