### PR TITLE
Added link to note-publish repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,4 @@ List of other interesting customizations, mainly involving third-party tools.
   - [Print BackLinks](https://github.com/RyanGreenup/Note-Taking-Tools/blob/master/List-BackLinks/ListBacklinks.md)
 - Automation:
   - [Git Synchronisation Schedule Script](https://github.com/evanshortiss/notable-git-sync-setup)
+  - [Publish to GitHub pages "Share via Link..." interceptor](https://github.com/thinkaliker/note-publish)


### PR DESCRIPTION
Haven't tested with Beta10 (last tested with maybe beta7 or 8) but hoping eventually to turn this into a plugin rather than an interceptor.